### PR TITLE
Remove links to stackoverflow.com in diamond dropdown

### DIFF
--- a/TopBarTweaks.user.js
+++ b/TopBarTweaks.user.js
@@ -60,10 +60,10 @@ $('.top-bar .-dialog-container').on('DOMNodeInserted', function(e)
   {
     var child = $('.header .-right');
     child.empty();
-    child.append('<a href="https://stackoverflow.com/admin/links">links</a>');
+    child.append('<a href="/admin/links">links</a>');
     child.append(' • ');
-    child.append('<a href="https://stackoverflow.com/admin">history</a>');
+    child.append('<a href="/admin">history</a>');
     child.append(' • ');
-    child.append('<a href="https://stackoverflow.com/admin/dashboard">flags</a>');
+    child.append('<a href="/admin/dashboard">flags</a>');
   }
 });


### PR DESCRIPTION
For non-SO mods, linking to Stack Overflow's mod dashboard breaks (unsurprisingly, I guess), so the "links", "history" and "flags" hyperlinks don't work.

My changes just use root-relative URLs instead.

— [Aurora0001](https://iot.stackexchange.com/users/12/aurora0001)